### PR TITLE
Updated the Spock Report Version to 1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testCompile "org.seleniumhq.selenium:selenium-edge-driver:$seleniumVersion"
 
     // Spock reports
-    testCompile( 'com.athaydes:spock-reports:1.3.2' ) {
+    testCompile( 'com.athaydes:spock-reports:1.4.0' ) {
         transitive = false // this avoids affecting your version of Groovy/Spock
     }
     testCompile 'org.slf4j:slf4j-api:1.7.13'
@@ -101,6 +101,8 @@ tasks.withType(Test) {
         exceptionFormat = 'full'
     }
     systemProperty 'com.athaydes.spockframework.report.outputDir', 'build/reports/spock'
+    systemProperty 'com.athaydes.spockframework.report.internal.HtmlReportCreator.inlineCss', false
+    systemProperty 'com.athaydes.spockframework.report.projectName',"<Your Project Name Here>"    
 }
 
 tasks.withType(GroovyCompile) {


### PR DESCRIPTION
And added:   
 systemProperty 'com.athaydes.spockframework.report.internal.HtmlReportCreator.inlineCss', false
 systemProperty 'com.athaydes.spockframework.report.projectName',"<Your Project Name here>"

In build.gradle to allow for better showing of the reports in Jenkins.